### PR TITLE
chore: adding a catalog-info.yaml file so this repo shows up in Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "dora-deploy-demo"
+  description: "This repository hosts Terraform example code with Actions to populate DORA metrics."
+  annotations:
+    github.com/project-slug: liatrio/dora-deploy-demo
+spec:
+  type: website
+  lifecycle: experimental
+  owner: "group:default/tag-o11y"


### PR DESCRIPTION
# docs: adding a catalog-info.yaml file so this repo shows up in Backstage

- This PR adds the catalog-info.yaml file for Backstage to read it. This will help us test out our DORA plugin, as this repo utilizes GitHub Deployments. 